### PR TITLE
Update lndrest.py

### DIFF
--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -170,7 +170,7 @@ class LndRestWallet(Wallet):
         try:
             r = await self.client.post(
                 url="/v1/channels/transactions",
-                json={"payment_request": bolt11, "fee_limit": lnrpc_fee_limit},
+                json={"payment_request": bolt11, "fee_limit": lnrpc_fee_limit, "allow_self_payment": true},
                 timeout=None,
             )
             r.raise_for_status()


### PR DESCRIPTION
- added the ability to receive self payments on the node

[issue] You have to enable circular payment on lnd.conf. Note that lnd.conf doesn't allow allow_self_payment parameter, that is why is necessary to define that on transaction.